### PR TITLE
Handle newlines in filenames

### DIFF
--- a/bomr
+++ b/bomr
@@ -37,8 +37,8 @@ function purge-file {
 }
 
 function purge-directory {
-    find "$1" -type f | while read f
-    do # TODO: This breaks for filenames with newlines.
+    find "$1" -type f -print0 | while read -d '' f
+    do
         purge-file "$f"
     done
 }


### PR DESCRIPTION
`find` can be instructed to print matching files separated by null bytes rather than newlines via the `-print0` action. `read` can be made to expect such delimiters with an empty `-d` flag. By their powers combined, `bomr` now handles filenames which contain newlines (and other mischievous characters).